### PR TITLE
Add server_timeout configuration for Kopf operator. Update Cyberdesk …

### DIFF
--- a/infra/kubevirt/cyberdesk-operator.yaml
+++ b/infra/kubevirt/cyberdesk-operator.yaml
@@ -84,7 +84,7 @@ spec:
       serviceAccountName: cyberdesk-operator
       containers:
       - name: operator
-        image: cyberdesk/cyberdesk-operator:v0.1.6
+        image: cyberdesk/cyberdesk-operator:v0.1.7
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080

--- a/services/cyberdesk-operator/handlers/controller.py
+++ b/services/cyberdesk-operator/handlers/controller.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from enum import Enum
 from supabase import create_client, Client
 from dotenv import load_dotenv
+from kopf import OperatorSettings # Import OperatorSettings
 
 TEST_USER_DATA_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'tests', 'test-user-data.yaml'))
 
@@ -218,6 +219,15 @@ def create_cloudinit_secret(meta, namespace, logger, **kwargs):
         raise
 
 # --- End Helper Functions ---
+
+@kopf.on.startup()
+def configure_kopf(settings: OperatorSettings, **_):
+    """Configure Kopf settings on startup."""
+    # Set a server timeout for watchers to potentially mitigate
+    # issues where connections drop after long idle periods.
+    # Value based on https://github.com/nolar/kopf/issues/1210
+    settings.watching.server_timeout = 210
+    logging.info(f"Set kopf watching server_timeout to {settings.watching.server_timeout} seconds.")
 
 def load_vm_template():
     """Load VM template from file"""


### PR DESCRIPTION
…operator image to v0.1.7 and configure Kopf settings

- Updated the operator image version from v0.1.6 to v0.1.7 in the deployment configuration.
- Added a startup configuration for Kopf to set the server timeout for watchers, improving connection stability.