### PR TITLE
Update network security rules to restrict inbound traffic and add rol…

### DIFF
--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -35,3 +35,15 @@ variable "aks_default_node_pool_max_count" {
   type        = number
   default     = 2
 }
+
+variable "developer_api_ips" {
+  type        = list(string)
+  description = "List of dedicated public IP addresses/CIDRs for the Developer-facing API app."
+  default     = ["0.0.0.0/0"]
+}
+
+variable "developer_vpn_ips" {
+  type        = list(string)
+  description = "List of public IP addresses/CIDRs for the developer VPN (for secure local access to the cluster)"
+  default     = ["0.0.0.0/0"]
+}


### PR DESCRIPTION
…e assignment for AKS managed identity

- Modified inbound HTTP and HTTPS rules to allow traffic only from specified developer IPs instead of all internet sources.
- Renamed rules for clarity to reflect the trusted sources.
- Added new variables for developer API and VPN IPs in the Terraform configuration.
- Introduced a role assignment for the AKS managed identity to manage route tables, ensuring proper permissions for Azure CNI usage.