### PR TITLE
Update Kubernetes configurations and gateway service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ user-data-base64.txt
 
 # Kubernetes secrets - DO NOT COMMIT REAL CREDENTIALS
 infra/kubernetes/cyberdesk-secret.yaml
+infra/kubernetes/checkpoint-cyberdesk-secret.yaml
 
 # Local development environment variables
 .env

--- a/infra/kubernetes/cyberdesk-operator.yaml
+++ b/infra/kubernetes/cyberdesk-operator.yaml
@@ -84,7 +84,7 @@ spec:
       serviceAccountName: cyberdesk-operator
       containers:
       - name: operator
-        image: cyberdesk/cyberdesk-operator:v0.1.8
+        image: cyberdesk/cyberdesk-operator:v0.1.9
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -144,7 +144,7 @@ data:
         spec:
           source:
             http:
-              url: https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img
+              url: https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img
           pvc:
             accessModes: [ReadWriteOnce]
             volumeMode: Filesystem
@@ -165,6 +165,7 @@ data:
             cpu:
               cores: 1
             devices:
+              autoattachGraphicsDevice: false
               disks:
                 - name: rootdisk
                   disk:
@@ -175,6 +176,10 @@ data:
               interfaces:
                 - name: default
                   masquerade: {} # TODO: Add specific ports
+              inputs:
+                - type: tablet
+                  name: tablet1
+                  bus: usb
             resources:
               requests:
                 memory: 2Gi

--- a/infra/kubernetes/gateway-deploy.yaml
+++ b/infra/kubernetes/gateway-deploy.yaml
@@ -51,7 +51,7 @@ spec:
       serviceAccountName: gateway
       containers:
       - name: gateway
-        image: cyberdesk/gateway:v0.1.14
+        image: cyberdesk/gateway:v0.1.15
         envFrom:
         - secretRef:
             name: supabase-credentials

--- a/services/gateway/README.md
+++ b/services/gateway/README.md
@@ -71,3 +71,14 @@ These instructions explain how to run the gateway service locally on your machin
 
 4.  **Access the Service:**
     The gateway should now be running and accessible at `http://localhost:3001` on your host machine. You can test endpoints like `http://localhost:3001/healthz`.
+
+5.  **For the noVNC stream, you need to run the following command:**
+    ```bash
+    kubectl get pods -n kubevirt
+
+    # Find the pod with id 'virt-launcher-<vm-id>-<pod-id>'
+
+    kubectl port-forward <pod-id> 5901:5901 -n kubevirt
+    ```
+
+    This will forward port 5901 on your host machine to port 5901 on the pod that runs the Kubevirt VM. This allows you to connect to the VM's desktop environment via the noVNC stream via the URL: `http://localhost:3001/vnc/<vm-id>`.


### PR DESCRIPTION
- Added checkpoint-cyberdesk-secret.yaml to .gitignore to prevent committing sensitive information.
- Updated cyberdesk-operator image version from v0.1.8 to v0.1.9 and changed the cloud image URL for VM deployment.
- Updated gateway image version from v0.1.14 to v0.1.15 for the latest features and fixes.
- Enhanced VNC proxy handling in main.py to connect to a websockify instance instead of KubeVirt directly, improving local development setup.
- Updated README with instructions for port-forwarding to access the noVNC stream.