### PR TITLE
Remove package-lock.json copy from Dockerfile to streamline the build…

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -22,7 +22,6 @@ RUN apt-get update -qq && \
 
 # Install node modules
 COPY package.json ./
-COPY package-lock.json ./
 RUN npm install --include=dev
 
 # Copy application code


### PR DESCRIPTION
… process and ensure consistent dependency management.